### PR TITLE
Fix: Persist stateInspectorIgnorePatterns input value (#52)

### DIFF
--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -127,11 +127,13 @@
             "hidden": "!data.enableStaleDetection"
         },
         "stateInspectorIgnorePatterns": {
+            "newLine": true,
             "type": "chips",
             "label": "State Inspector ignore patterns",
             "help": "State patterns to exclude from all inspections (e.g., system.*, admin.*, mydevice.*)",
             "delimiter": ",",
-            "sm": 12
+            "sm": 12,
+            "default": []
         }
     }
 }

--- a/main.js
+++ b/main.js
@@ -486,7 +486,7 @@ class Health extends utils.Adapter {
     async runDuplicateDetection() {
         if (!this.duplicateInspector) {
             const threshold = this.config.duplicateSimilarityThreshold || 0.9;
-            const ignorePatterns = this.config.stateInspectorIgnorePatterns || [];
+            const ignorePatterns = this._parseIgnorePatterns(this.config.stateInspectorIgnorePatterns);
             this.duplicateInspector = new DuplicateStateInspector(this, threshold, ignorePatterns);
             await this.duplicateInspector.init();
         }
@@ -505,7 +505,7 @@ class Health extends utils.Adapter {
      */
     async runOrphanDetection() {
         if (!this.orphanedInspector) {
-            const ignorePatterns = this.config.stateInspectorIgnorePatterns || [];
+            const ignorePatterns = this._parseIgnorePatterns(this.config.stateInspectorIgnorePatterns);
             this.orphanedInspector = new OrphanedStateInspector(this, ignorePatterns);
             await this.orphanedInspector.init();
         }
@@ -525,7 +525,7 @@ class Health extends utils.Adapter {
     async runStaleDetection() {
         if (!this.staleInspector) {
             const thresholdHours = this.config.staleThresholdHours || 24;
-            const ignorePatterns = this.config.stateInspectorIgnorePatterns || [];
+            const ignorePatterns = this._parseIgnorePatterns(this.config.stateInspectorIgnorePatterns);
             this.staleInspector = new StaleStateInspector(this, thresholdHours, ignorePatterns);
             await this.staleInspector.init();
         }
@@ -868,6 +868,26 @@ class Health extends utils.Adapter {
         } catch {
             callback();
         }
+    }
+
+    /**
+     * Parse ignore patterns from config.
+     * Handles both array and string (comma/newline delimited) formats.
+     * @param {string|string[]|null|undefined} patterns
+     * @returns {string[]}
+     */
+    _parseIgnorePatterns(patterns) {
+        if (Array.isArray(patterns)) {
+            return patterns.filter(p => typeof p === 'string' && p.trim()).map(p => p.trim());
+        }
+        if (typeof patterns === 'string' && patterns.trim()) {
+            // Split by comma or newline
+            return patterns
+                .split(/[,\n]/)
+                .map(p => p.trim())
+                .filter(p => p);
+        }
+        return [];
     }
 }
 


### PR DESCRIPTION
## Description
Fixes #52 - Input value in stateInspectorIgnorePatterns field was not being saved

## Changes
- Added `newLine: true` to chips field in jsonConfig.json to ensure proper UI layout
- Added `default: []` to prevent undefined state
- Implemented `_parseIgnorePatterns()` helper method to handle both array and string (comma/newline delimited) formats
- Updated all three state inspector detectors to use the new parser

## Root Cause
The chips field was not properly persisting values due to missing newLine property and potential format mismatch between UI input and internal state handling.

## Testing
- Ran `npm test` - all 96 tests pass ✅
- Tested with dev-server watch (adapter starts cleanly, no errors)
- Input persistence now works correctly