### PR TITLE
Fix #80: relax stale-state filtering and initialize inspector summary values

### DIFF
--- a/lib/state-inspector/stale-detection.js
+++ b/lib/state-inspector/stale-detection.js
@@ -124,7 +124,7 @@ class StaleStateInspector {
         const runningAdapters = await this.getRunningAdapters();
         
         let processed = 0;
-        let skippedReadOnly = 0;
+        let skippedNonRelevant = 0;
         let skippedInactiveAdapter = 0;
 
         for (const [stateId, state] of Object.entries(allStates)) {
@@ -151,12 +151,14 @@ class StaleStateInspector {
                 continue;
             }
 
-            // Skip read-only states (common.write === false or common.read === true && common.write === false/undefined)
+            // Include both readable and writable states.
+            // Only skip states that are neither readable nor writable,
+            // because those cannot be meaningfully inspected.
             const isWritable = obj.common.write === true;
-            const isReadOnly = obj.common.read === true && !isWritable;
-            
-            if (!isWritable || isReadOnly) {
-                skippedReadOnly++;
+            const isReadable = obj.common.read === true;
+
+            if (!isWritable && !isReadable) {
+                skippedNonRelevant++;
                 continue;
             }
 
@@ -179,12 +181,12 @@ class StaleStateInspector {
                     ageHours: Math.round(age / (60 * 60 * 1000)),
                     value: state.val,
                     writable: isWritable,
-                    readOnly: isReadOnly
+                    readOnly: isReadable && !isWritable
                 });
             }
         }
         
-        this.adapter.log.debug(`Skipped ${skippedReadOnly} read-only states, ${skippedInactiveAdapter} states from inactive adapters.`);
+        this.adapter.log.debug(`Skipped ${skippedNonRelevant} non-relevant states, ${skippedInactiveAdapter} states from inactive adapters.`);
 
         // Sort by age (oldest first)
         this.staleStates.sort((a, b) => b.ageHours - a.ageHours);

--- a/main.js
+++ b/main.js
@@ -436,6 +436,25 @@ class Health extends utils.Adapter {
             },
             native: {},
         });
+
+        // Initialize inspector summary values to avoid null values in admin UI
+        // before the first complete scan has finished.
+        await this.setStateAsync('stateInspector.totalIssues', 0, true);
+        await this.setStateAsync('stateInspector.orphaned', 0, true);
+        await this.setStateAsync('stateInspector.stale', 0, true);
+        await this.setStateAsync('stateInspector.duplicates', 0, true);
+        await this.setStateAsync('stateInspector.safeToDeleteCount', 0, true);
+        await this.setStateAsync('stateInspector.reviewRequiredCount', 0, true);
+
+        await this.setStateAsync('stateInspector.details', JSON.stringify({
+            timestamp: null,
+            totalIssues: 0,
+            categories: {
+                orphaned: 0,
+                stale: 0,
+                duplicates: 0
+            }
+        }, null, 2), true);
     }
 
     /**

--- a/test/stale-state-inspector.test.js
+++ b/test/stale-state-inspector.test.js
@@ -102,7 +102,7 @@ describe('StaleStateInspector', () => {
             assert.strictEqual(inspector.staleStates[0].adapter, 'mqtt.0');
         });
 
-        it('should skip read-only states (common.write === false)', async () => {
+        it('should include read-only states (common.write === false)', async () => {
             const adapter = new MockAdapter();
             const now = Date.now();
             const oldTimestamp = now - (25 * 60 * 60 * 1000);
@@ -128,20 +128,20 @@ describe('StaleStateInspector', () => {
             const inspector = new StaleStateInspector(adapter, 24, []);
             await inspector.inspect();
 
-            assert.strictEqual(inspector.staleStates.length, 0, 'Should skip read-only states');
+            assert.strictEqual(inspector.staleStates.length, 1, 'Should include read-only states');
         });
 
-        it('should skip states with read=true and write=undefined (read-only)', async () => {
+        it('should include states with read=true and write=undefined (implicitly read-only)', async () => {
             const adapter = new MockAdapter();
             const now = Date.now();
             const oldTimestamp = now - (25 * 60 * 60 * 1000);
 
             adapter.foreignStates = {
-                'mqtt.0.info.connection': { val: true, ts: oldTimestamp }
+                'mqtt.0.sensor.connection': { val: true, ts: oldTimestamp }
             };
 
             adapter.foreignObjects = {
-                'mqtt.0.info.connection': {
+                'mqtt.0.sensor.connection': {
                     common: {
                         name: 'Connection',
                         type: 'boolean',
@@ -157,7 +157,7 @@ describe('StaleStateInspector', () => {
             const inspector = new StaleStateInspector(adapter, 24, []);
             await inspector.inspect();
 
-            assert.strictEqual(inspector.staleStates.length, 0, 'Should skip implicitly read-only states');
+            assert.strictEqual(inspector.staleStates.length, 1, 'Should include implicitly read-only states');
         });
 
         it('should skip states from inactive adapters', async () => {


### PR DESCRIPTION
## Summary
This addresses issue #80 (State Inspector showing null/no results).

### Changes
- **Stale detection:** no longer requires `common.write === true`; read-only states (`read: true`) are now considered for staleness checks.
- Skip only states that are neither readable nor writable.
- **Startup defaults:** initialize State Inspector summary states to avoid `null` values before first completed scan.

### Why
- The previous stale filter was too strict and excluded many real-world sensor states (read-only).
- UI counters showed `null` until a full scan finished.

### Validation
- Updated stale inspector tests for new behavior.
- Ran full test suite successfully (`npm test`).

Closes #80.
