### PR TITLE
Fix #105: Initialize Redis monitoring states to avoid null values

### DIFF
--- a/main.js
+++ b/main.js
@@ -499,6 +499,22 @@ class Health extends utils.Adapter {
             native: {},
         });
 
+        // Initialize Redis monitoring states to avoid null values in admin UI
+        // before the first check has been completed.
+        await this.setStateAsync('redis.status', 'skipped', true);
+        await this.setStateAsync('redis.connected', false, true);
+        await this.setStateAsync('redis.memoryUsedPercent', 0, true);
+        await this.setStateAsync('redis.memoryUsedBytes', 0, true);
+        await this.setStateAsync('redis.keys', 0, true);
+        await this.setStateAsync('redis.evictedKeys', 0, true);
+        await this.setStateAsync('redis.latencyMs', 0, true);
+        await this.setStateAsync('redis.details', JSON.stringify({
+            status: 'skipped',
+            reason: 'Not yet checked',
+            timestamp: null
+        }, null, 2), true);
+        await this.setStateAsync('redis.timestamp', Date.now(), true);
+
         // Initialize inspector summary values to avoid null values in admin UI
         // before the first complete scan has finished.
         await this.setStateAsync('stateInspector.totalIssues', 0, true);


### PR DESCRIPTION
## Summary
Fixes #105: Redis monitoring states were defined in createStates() but never initialized with values, causing null/undefined states in the admin UI before the first health check runs.

## Root Cause
- Redis states (redis.status, redis.connected, redis.memoryUsedPercent, etc.) were created as object definitions only
- setState() was never called during initialization, leaving states undefined
- Only populated during runRedisCheck(), but users see null before that

## Solution
Added initialization of all redis monitoring states at the end of createStates() with sensible default values:
- redis.status → 'skipped'
- redis.connected → false
- Numeric values → 0
- redis.details → JSON with default structure
- redis.timestamp → current time

Follows the same pattern already used for stateInspector state initialization.

## Testing
✅ All 178 unit tests passed
✅ Code follows existing patterns from stateInspector initialization
✅ No breaking changes

## Limitations
- dev-server testing skipped (not available in build environment)
- Runtime validation deferred to reviewer's test system

Note: Tested with npm test before PR submission