### PR TITLE
Fix #114: Improve log monitor robustness

### DIFF
--- a/lib/health-checks/log-monitor.js
+++ b/lib/health-checks/log-monitor.js
@@ -95,12 +95,24 @@ class LogMonitor {
                 { lines: this.config.maxLogLines }
             );
             
-            if (!logs || !Array.isArray(logs)) {
-                this.adapter.log.warn('getLog returned invalid data');
+            // Handle direct array response
+            if (Array.isArray(logs)) {
+                return logs;
+            }
+            
+            // Handle wrapped array response (some hosts wrap result in an object)
+            if (logs && typeof logs === 'object' && Array.isArray(logs.logs)) {
+                return logs.logs;
+            }
+            
+            // No valid logs received
+            if (!logs) {
+                this.adapter.log.warn('getLog returned no data');
                 return [];
             }
             
-            return logs;
+            this.adapter.log.warn(`getLog returned unexpected data type: ${typeof logs}`);
+            return [];
         } catch (err) {
             this.adapter.log.error(`Failed to fetch logs: ${err.message}`);
             return [];


### PR DESCRIPTION
## Problem
The log monitoring feature was not properly handling the response from the host's getLog API call, potentially resulting in all log datapoints remaining null.

## Solution
- Improved error handling in LogMonitor.fetchLogs() to handle both direct array responses and wrapped responses
- Added null/type validation
- Better error messages for debugging host compatibility issues
- All existing tests pass (178/178)

## Testing
- Ran full test suite: npm test
- All LogMonitor tests pass
- No breaking changes to existing functionality