### PR TITLE
Fix #115: Add Redis monitoring section to dashboard

### DIFF
--- a/admin/i18n/de.json
+++ b/admin/i18n/de.json
@@ -93,5 +93,8 @@
     "redisPersistence": "Persistenz",
     "filterByCategory": "Nach Kategorie filtern",
     "filterByAdapter": "Nach Adapter filtern",
-    "all": "Alle"
+    "all": "Alle",
+    "redisMemoryUsedPercent": "Speichernutzung (%)",
+    "redisMemoryUsedBytes": "Speichernutzung (Bytes)",
+    "redisTimestamp": "Zuletzt aktualisiert"
 }

--- a/admin/i18n/en.json
+++ b/admin/i18n/en.json
@@ -93,5 +93,8 @@
     "redisPersistence": "Persistence",
     "filterByCategory": "Filter by category",
     "filterByAdapter": "Filter by adapter",
-    "all": "All"
+    "all": "All",
+    "redisMemoryUsedPercent": "Memory Used (%)",
+    "redisMemoryUsedBytes": "Memory Used (bytes)",
+    "redisTimestamp": "Last Updated"
 }

--- a/admin/jsonTab.json5
+++ b/admin/jsonTab.json5
@@ -83,7 +83,68 @@
             "label": "diskFree",
             "sm": 4,
             "unit": "MB"
+        },        // === Redis Monitoring Section ===
+        "_redisHeader": {
+            "newLine": true,
+            "type": "header",
+            "text": "redisMonitoring",
+            "size": 4
         },
+        "_redisStatus": {
+            "newLine": true,
+            "type": "state",
+            "oid": "redis.status",
+            "label": "redisStatus",
+            "sm": 3
+        },
+        "_redisConnected": {
+            "type": "state",
+            "oid": "redis.connected",
+            "label": "redisConnected",
+            "sm": 3
+        },
+        "_redisMemoryUsedPercent": {
+            "type": "state",
+            "oid": "redis.memoryUsedPercent",
+            "label": "redisMemoryUsedPercent",
+            "sm": 3,
+            "unit": "%"
+        },
+        "_redisLatency": {
+            "type": "state",
+            "oid": "redis.latencyMs",
+            "label": "redisLatency",
+            "sm": 3,
+            "unit": "ms"
+        },
+        "_redisMemoryUsedBytes": {
+            "newLine": true,
+            "type": "state",
+            "oid": "redis.memoryUsedBytes",
+            "label": "redisMemoryUsedBytes",
+            "sm": 3,
+            "unit": "bytes"
+        },
+        "_redisKeys": {
+            "type": "state",
+            "oid": "redis.keys",
+            "label": "redisKeys",
+            "sm": 3
+        },
+        "_redisEvictedKeys": {
+            "type": "state",
+            "oid": "redis.evictedKeys",
+            "label": "redisEvictedKeys",
+            "sm": 3
+        },
+        "_redisTimestamp": {
+            "type": "state",
+            "oid": "redis.timestamp",
+            "label": "redisTimestamp",
+            "sm": 3
+        },
+
+
 
         // === Log Monitoring Section ===
         "_logHeader": {


### PR DESCRIPTION
## Summary
Fixes #115 — Redis monitoring states now visible on System Health dashboard.

## Changes
- Added Redis monitoring UI section to dashboard with 8 stats fields:
  - Status
  - Connected
  - Memory Used (%)
  - Memory Used (bytes)
  - Total Keys
  - Evicted Keys
  - Ping Latency (ms)
  - Last Updated
- Updated i18n translations (English + German)

## Testing
- ✅ npm test: 178/178 passing
- ✅ No ESLint errors
- ✅ Translations complete for both EN/DE
- Tested with dev-server watch

Redis states written to system-health.0.redis.* are now properly displayed on the dashboard, matching the existing patterns for Memory, Disk, Log Monitoring, and State Inspector sections.