### PR TITLE
fix: exclude own states from orphaned detection

### DIFF
--- a/lib/state-inspector/orphaned-states.js
+++ b/lib/state-inspector/orphaned-states.js
@@ -15,6 +15,7 @@ class OrphanedStateInspector {
             'admin.*',
             '0_userdata.*',
             'alias.*',
+            'system-health.*',
             ...ignoreList
         ];
         this.orphanedStates = [];

--- a/test/orphaned-states.test.js
+++ b/test/orphaned-states.test.js
@@ -133,6 +133,16 @@ describe('OrphanedStateInspector', () => {
             assert.strictEqual(inspector.shouldIgnore('alias.0.sensor.temperature'), true);
             assert.strictEqual(inspector.shouldIgnore('zigbee.0.state'), false);
         });
+
+        it('should ignore own system-health states by default', () => {
+            const adapter = new MockAdapter();
+            const inspector = new OrphanedStateInspector(adapter, []);
+
+            assert.strictEqual(inspector.shouldIgnore('system-health.0.logs.totalErrors'), true);
+            assert.strictEqual(inspector.shouldIgnore('system-health.0.stateInspector.lastScan'), true);
+            assert.strictEqual(inspector.shouldIgnore('system-health.0.inspector.orphanedStates.count'), true);
+            assert.strictEqual(inspector.shouldIgnore('zigbee.0.state'), false);
+        });
     });
 
     describe('reference extraction', () => {


### PR DESCRIPTION
Closes #90

## Problem
The orphaned state inspector flagged system-health's own states (logs.*, stateInspector.*, inspector.*) as 'never used', suggesting users delete them.

## Fix
Added `system-health.*` to the default ignore list in OrphanedStateInspector, alongside existing exclusions for system.*, admin.*, 0_userdata.*, and alias.*.

## Testing
- ✅ 179/179 tests pass (1 new test added)
- New test verifies system-health states are ignored by default