### PR TITLE
fix: add scalar disk states for dashboard widgets

### DIFF
--- a/lib/health-checks/disk-monitor.js
+++ b/lib/health-checks/disk-monitor.js
@@ -119,6 +119,58 @@ class DiskMonitor {
             },
             native: {}
         });
+
+        await this.adapter.setObjectNotExistsAsync(`${baseId}.usedPercent`, {
+            type: 'state',
+            common: {
+                name: 'Disk used percent (root partition)',
+                type: 'number',
+                role: 'value.percent',
+                unit: '%',
+                read: true,
+                write: false
+            },
+            native: {}
+        });
+
+        await this.adapter.setObjectNotExistsAsync(`${baseId}.freeMB`, {
+            type: 'state',
+            common: {
+                name: 'Disk free space (root partition)',
+                type: 'number',
+                role: 'value',
+                unit: 'MB',
+                read: true,
+                write: false
+            },
+            native: {}
+        });
+
+        await this.adapter.setObjectNotExistsAsync(`${baseId}.totalMB`, {
+            type: 'state',
+            common: {
+                name: 'Disk total size (root partition)',
+                type: 'number',
+                role: 'value',
+                unit: 'MB',
+                read: true,
+                write: false
+            },
+            native: {}
+        });
+
+        await this.adapter.setObjectNotExistsAsync(`${baseId}.usedMB`, {
+            type: 'state',
+            common: {
+                name: 'Disk used space (root partition)',
+                type: 'number',
+                role: 'value',
+                unit: 'MB',
+                read: true,
+                write: false
+            },
+            native: {}
+        });
     }
 
     /**
@@ -159,6 +211,15 @@ class DiskMonitor {
             await this.adapter.setStateAsync('disk.status', status, true);
             await this.adapter.setStateAsync('disk.warnings', warnings, true);
             await this.adapter.setStateAsync('disk.trends', JSON.stringify(trends), true);
+
+            // Set scalar states for root partition (for dashboard widgets)
+            const rootPartition = partitions.find(p => p.mountPoint === '/') || partitions[0];
+            if (rootPartition) {
+                await this.adapter.setStateAsync('disk.usedPercent', rootPartition.usedPercent, true);
+                await this.adapter.setStateAsync('disk.freeMB', rootPartition.freeMB, true);
+                await this.adapter.setStateAsync('disk.totalMB', rootPartition.totalMB, true);
+                await this.adapter.setStateAsync('disk.usedMB', rootPartition.usedMB, true);
+            }
             
             // Persist history
             await this.saveHistory();

--- a/test/disk-monitor.test.js
+++ b/test/disk-monitor.test.js
@@ -57,6 +57,33 @@ describe('DiskMonitor', () => {
             assert.ok(adapter.objects['system-health.0.disk.warnings']);
             assert.ok(adapter.objects['system-health.0.disk.trends']);
             assert.ok(adapter.objects['system-health.0.disk.history']);
+            assert.ok(adapter.objects['system-health.0.disk.usedPercent']);
+            assert.ok(adapter.objects['system-health.0.disk.freeMB']);
+            assert.ok(adapter.objects['system-health.0.disk.totalMB']);
+            assert.ok(adapter.objects['system-health.0.disk.usedMB']);
+        });
+
+        it('should define scalar states with correct types and units', async () => {
+            const adapter = new MockAdapter();
+            const diskMonitor = new DiskMonitor(adapter);
+
+            await diskMonitor.createStates();
+
+            const usedPercent = adapter.objects['system-health.0.disk.usedPercent'];
+            assert.strictEqual(usedPercent.common.type, 'number');
+            assert.strictEqual(usedPercent.common.unit, '%');
+
+            const freeMB = adapter.objects['system-health.0.disk.freeMB'];
+            assert.strictEqual(freeMB.common.type, 'number');
+            assert.strictEqual(freeMB.common.unit, 'MB');
+
+            const totalMB = adapter.objects['system-health.0.disk.totalMB'];
+            assert.strictEqual(totalMB.common.type, 'number');
+            assert.strictEqual(totalMB.common.unit, 'MB');
+
+            const usedMB = adapter.objects['system-health.0.disk.usedMB'];
+            assert.strictEqual(usedMB.common.type, 'number');
+            assert.strictEqual(usedMB.common.unit, 'MB');
         });
     });
 
@@ -251,6 +278,41 @@ describe('DiskMonitor', () => {
             const warnings = diskMonitor.generateWarnings(partitions, trends);
             
             assert.strictEqual(warnings, '');
+        });
+    });
+
+    describe('scalar states', () => {
+        it('should set scalar states from root partition during measure', async () => {
+            const adapter = new MockAdapter();
+            const diskMonitor = new DiskMonitor(adapter, { mountPoints: ['/'] });
+
+            // Override getDiskUsage to return controlled data
+            diskMonitor.getDiskUsage = async () => [
+                { filesystem: '/dev/sda1', mountPoint: '/', totalMB: 50000, usedMB: 20000, freeMB: 30000, usedPercent: 40 }
+            ];
+
+            await diskMonitor.createStates();
+            await diskMonitor.measure();
+
+            assert.strictEqual(adapter.states['system-health.0.disk.usedPercent'].val, 40);
+            assert.strictEqual(adapter.states['system-health.0.disk.freeMB'].val, 30000);
+            assert.strictEqual(adapter.states['system-health.0.disk.totalMB'].val, 50000);
+            assert.strictEqual(adapter.states['system-health.0.disk.usedMB'].val, 20000);
+        });
+
+        it('should fall back to first partition if no root partition found', async () => {
+            const adapter = new MockAdapter();
+            const diskMonitor = new DiskMonitor(adapter, { mountPoints: ['/data'] });
+
+            diskMonitor.getDiskUsage = async () => [
+                { filesystem: '/dev/sdb1', mountPoint: '/data', totalMB: 100000, usedMB: 60000, freeMB: 40000, usedPercent: 60 }
+            ];
+
+            await diskMonitor.createStates();
+            await diskMonitor.measure();
+
+            assert.strictEqual(adapter.states['system-health.0.disk.usedPercent'].val, 60);
+            assert.strictEqual(adapter.states['system-health.0.disk.freeMB'].val, 40000);
         });
     });
 


### PR DESCRIPTION
## Problem

Dashboard disk widgets reference non-existent states (`disk.usedPercent`, `disk.freeMB`, etc.), but the disk monitor only wrote `disk.partitions` as a JSON array.

Fixes #150

## Changes

### `lib/health-checks/disk-monitor.js`
- **`createStates()`**: Added state definitions for:
  - `disk.usedPercent` (number, unit: %)
  - `disk.freeMB` (number, unit: MB)
  - `disk.totalMB` (number, unit: MB)
  - `disk.usedMB` (number, unit: MB)
- **`measure()`**: After setting `disk.partitions`, extract the root partition (`/`) — or fall back to the first partition — and set the four scalar states.

### `test/disk-monitor.test.js`
- Added test: all four scalar state objects are created
- Added test: scalar states have correct types and units
- Added test: scalar values are correctly set from root partition during `measure()`
- Added test: fallback to first partition when no root partition is found

## Test Results

All 17 tests pass ✅