### PR TITLE
fix(io-package): add missing timestamp state definitions

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -72,5 +72,38 @@
         "redisLatencyWarningMs": 100
     },
     "objects": [],
-    "instanceObjects": []
+    "instanceObjects": [
+        {
+            "_id": "memory.timestamp",
+            "type": "state",
+            "common": {
+                "name": {
+                    "en": "Last memory check timestamp",
+                    "de": "Zeitstempel der letzten Speicherprüfung"
+                },
+                "type": "number",
+                "role": "value.time",
+                "read": true,
+                "write": false,
+                "unit": "ms"
+            },
+            "native": {}
+        },
+        {
+            "_id": "disk.timestamp",
+            "type": "state",
+            "common": {
+                "name": {
+                    "en": "Last disk check timestamp",
+                    "de": "Zeitstempel der letzten Festplattenprüfung"
+                },
+                "type": "number",
+                "role": "value.time",
+                "read": true,
+                "write": false,
+                "unit": "ms"
+            },
+            "native": {}
+        }
+    ]
 }


### PR DESCRIPTION
## Summary

Fixes #171

PR #170 added timestamp states for memory and disk monitoring in `main.js` and `disk-monitor.js`, but the state definitions were missing from `io-package.json`.

## Problem

Without `instanceObjects` definitions, the states are never created even though `setObjectNotExistsAsync()` is called in the code. This is because ioBroker only creates objects during adapter installation/upload if they are defined in io-package.json.

## Changes

Added to `instanceObjects` array:
- `memory.timestamp`: Last memory check timestamp
- `disk.timestamp`: Last disk check timestamp

Note: `logs.timestamp` already existed before PR #170, so it was not affected.

## Testing

After this fix:
1. Reinstall adapter or run `iobroker upload system-health`
2. States should be created: `system-health.0.memory.timestamp` and `system-health.0.disk.timestamp`
3. Dashboard widgets should show timestamps instead of N/A